### PR TITLE
Replace manual handle memory management with GC allocated space

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ lazy val commonSettings = Seq(
   ),
   libraryDependencies += "com.lihaoyi" %%% "utest" % "0.8.3" % Test,
   testFrameworks += new TestFramework("utest.runner.Framework"),
-  nativeConfig ~= {_.withMultithreading(false)},
 )
 
 lazy val core = project


### PR DESCRIPTION
Fixes the segmentation faults when clearing timer multiple times. There was no way to determine when Timer was already free. On some systems it was fine (MacOS) as the memory was not reused, on others (Ubuntu) it seems like retained memory was reallocated and overridden leading to segmentation fault in a call to `uv_close` 

New approach makes sure that as long as we have handle to Timer/Poll the memory would never be retained and overridden. It also allows to skip reference counting to prevent GCing the callbacks. 

